### PR TITLE
Update fes.py (BUG!)

### DIFF
--- a/pymbar/fes.py
+++ b/pymbar/fes.py
@@ -1474,8 +1474,14 @@ class FES:
                 fx_vals[i] = np.nan
                 dfx_vals[i] = np.nan
                 continue
-
-            bin_label = histogram_data["bin_label"][tuple(l)]
+            
+            # edit by Reilly Osadchey Brown 6.8.2023
+            # original line: bin_label = histogram_data["bin_label"][tuple(l)]
+            # Key Error is now not thrown when the key doesn't exist in dictionary
+            # Instead it returns -1 such that the bin gets NaN value but at least it doesn't crash
+            # this issue is likely due to somethign going wrong upstream 
+            bin_label = histogram_data["bin_label"].get( tuple(l) , -1) # return -1 for not found key
+            
             if bin_label >= 0:
                 fx_vals[i] = f_i[bin_order[bin_label]]
                 dfx_vals[i] = df_i[bin_order[bin_label]]


### PR DESCRIPTION
This is a one-line code change to mitigate a bug that results in histogramming exiting with a key error.  For some reason, histogram bins that actually ARE populated are not correctly being added to the histogram_data dictionary. When the free energy for that bin is meant to be pulled, that bin doesn't exist in the dictionary and the KeyError is thrown. This fix assigns a default value of -1 to the bin_label if the key isn't present nstead of throwing this exception, and thus can allow the user to bypass the troubled bin(s) and still get a free energy surface. This fix does not find the root cause of the issue. I would be happy to provide the example which resulted in me finding the bug, but would require transferring many files.